### PR TITLE
fixed test so it stringifies both sides

### DIFF
--- a/t/530_sereal.t
+++ b/t/530_sereal.t
@@ -30,8 +30,8 @@ BEGIN {
     is(scalar @$decoded, 2, 'ARRAY has two elements');
     isa_ok($decoded->[0], 'Time::Moment', 'first element');
     isa_ok($decoded->[1], 'Time::Moment', 'second element');
-    is($decoded->[0], $moments[0]->to_string, 'first element has right time');
-    is($decoded->[1], $moments[1]->to_string, 'second element has right time');
+    is($decoded->[0]->to_string, $moments[0]->to_string, 'first element has right time');
+    is($decoded->[1]->to_string, $moments[1]->to_string, 'second element has right time');
 }
 
 done_testing();


### PR DESCRIPTION
There's an issue on perl 5.8.9 (possibly others but cpantesters is down so I can't check, but it doesn't seem to happen on 5.20) whereby the sereal test fails (on modern Test::More, probably due to https://metacpan.org/changes/distribution/Test-Simple#L212)

Calling to_string on both sides fixes that.

it's a little tricky to pin down as this is the test failure I saw:

```
t/530_sereal.t .......... 1/?
#   Failed test 'first element has right time'
#   at t/530_sereal.t line 33.
#          got: '2012-12-24T15:30:45.123456789+01:00'
#     expected: '2012-12-24T15:30:45.123456789+01:00'
#   Failed test 'second element has right time'
#   at t/530_sereal.t line 36.
#          got: '2012-12-24T15:30:45.987654321+01:00'
#     expected: '2012-12-24T15:30:45.987654321+01:00'
```

If we inspect those objects further:

```
$VAR1 = bless( do{\(my $o = '��k��[<')}, 'Time::Moment' );
$VAR2 = '2012-12-24T15:30:45.123456789+01:00';

$VAR1 = bless( do{\(my $o = '��k��h�:<')}, 'Time::Moment' );
$VAR2 = '2012-12-24T15:30:45.987654321+01:00';
```