### PR TITLE
Include stdbool.h if compiler reports C99 compliance or is gcc >= 3.0

### DIFF
--- a/src/dt_config.h
+++ b/src/dt_config.h
@@ -26,10 +26,10 @@
 #ifndef __DT_CONFIG_H__
 #define __DT_CONFIG_H__
 
-#if !(defined(__sun) && defined(__SVR4))
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
+    (defined(__GNUC__) && __GNUC__ >= 3) || \
+    (defined(_MSC_VER) && _MSC_VER >= 1800)
 #  include <stdbool.h>
-#endif
 #endif
 
 #if !defined(__cplusplus) && !defined(__bool_true_false_are_defined)


### PR DESCRIPTION
The macro test around the inclusion of `stdbool.h` is way too broad and doesn't take into account compiler abilities. `stdbool.h` was defined in C99, and was introduced with GCC 3.0. Rather than cut out the entirety of Solaris (Solaris 10 and 11 include `stdbool.h`, as does any illumos distribution), we should test for compiler platform C99 compliance. This allows `Time::Moment` to compile on Solaris and illumos using GCC. Tested under macOS+brew++LLVM as well.